### PR TITLE
Add an option to choose the name for the memfd

### DIFF
--- a/AndKittyInjector/src/Injector/KittyInjector.cpp
+++ b/AndKittyInjector/src/Injector/KittyInjector.cpp
@@ -426,12 +426,12 @@ inject_elf_info_t KittyInjector::inject(const std::string &elfPath, const std::s
     if (!emulate)
     {
         KITTY_LOGI("Injector: using nativeInject...");
-        injected = nativeInject(libFile, &bCalldlerror, memfdName);
+        injected = nativeInject(libFile, memfdName, &bCalldlerror);
     }
     else
     {
         KITTY_LOGI("Injector: using emuInject...");
-        injected = emuInject(libFile, &bCalldlerror);
+        injected = emuInject(libFile, memfdName, &bCalldlerror);
     }
 
     KITTY_LOGI("Injector: Library Handle (%p).", (void *)injected.dl_handle);
@@ -533,7 +533,7 @@ inject_elf_info_t KittyInjector::inject(const std::string &elfPath, const std::s
     return injected;
 }
 
-inject_elf_info_t KittyInjector::nativeInject(KittyIOFile &elfFile, bool *bCalldlerror, const std::string &memfdName)
+inject_elf_info_t KittyInjector::nativeInject(KittyIOFile &elfFile, const std::string &memfdName, bool *bCalldlerror)
 {
     inject_elf_info_t info{};
     info.is_native = true;
@@ -597,7 +597,7 @@ inject_elf_info_t KittyInjector::nativeInject(KittyIOFile &elfFile, bool *bCalld
         extinfo.flags = ANDROID_DLEXT_USE_LIBRARY_FD;
         extinfo.library_fd = rmemfd;
 
-        uintptr_t rdlextinfo = kGET_ALIGIN_UP(_rbuffer + memfd_rand.size() + 1);
+        uintptr_t rdlextinfo = kGET_ALIGIN_UP(_rbuffer + memfdName.size() + 1);
         if (!_kMgr->writeMem(rdlextinfo, &extinfo, sizeof(extinfo)))
         {
             KITTY_LOGE("nativeInject: Failed to write dlextinfo into stack!");
@@ -607,8 +607,8 @@ inject_elf_info_t KittyInjector::nativeInject(KittyIOFile &elfFile, bool *bCalld
         info.dl_handle = _kMgr->trace.callFunctionFrom(_dl_caller, _rdlopen_ext, _rbuffer, _cfg.rtdl_flags, rdlextinfo);
         if (info.dl_handle != 0)
         {
-            info.soinfo = _kMgr->linkerScanner.findSoInfo("/memfd:" + memfd_rand);
-            info.elf = _kMgr->elfScanner.findElf("/memfd:" + memfd_rand, EScanElfType::Native);
+            info.soinfo = _kMgr->linkerScanner.findSoInfo("/memfd:" + memfdName);
+            info.elf = _kMgr->elfScanner.findElf("/memfd:" + memfdName, EScanElfType::Native);
             if (!info.elf.isValid())
             {
                 info.elf = _kMgr->elfScanner.createWithSoInfo(info.soinfo);
@@ -638,7 +638,7 @@ inject_elf_info_t KittyInjector::nativeInject(KittyIOFile &elfFile, bool *bCalld
     return info;
 }
 
-inject_elf_info_t KittyInjector::emuInject(KittyIOFile &elfFile, bool *bCalldlerror)
+inject_elf_info_t KittyInjector::emuInject(KittyIOFile &elfFile, const std::string &memfdName, bool *bCalldlerror)
 {
     _kMgr->nbScanner.init();
 
@@ -769,10 +769,9 @@ inject_elf_info_t KittyInjector::emuInject(KittyIOFile &elfFile, bool *bCalldler
     };
 
     auto do_memfd_dlopen = [&]() -> void {
-        std::string memfd_rand = KittyUtils::String::random(KittyUtils::randInt(5, 12));
-        KITTY_LOGI("emuInject: memfd Name (\"%s\").", memfd_rand.c_str());
+        KITTY_LOGI("emuInject: memfd Name (\"%s\").", memfdName.c_str());
 
-        if (!_kMgr->writeMemStr(_rbuffer, memfd_rand))
+        if (!_kMgr->writeMemStr(_rbuffer, memfdName))
         {
             KITTY_LOGE("emuInject: Failed to write memfd name into stack!");
             return;
@@ -804,8 +803,8 @@ inject_elf_info_t KittyInjector::emuInject(KittyIOFile &elfFile, bool *bCalldler
             // init nb scanner after emu dlopen
             _kMgr->nbScanner.init();
 
-            info.soinfo = _kMgr->nbScanner.findSoInfo("/memfd:" + memfd_rand);
-            info.elf = _kMgr->elfScanner.findElf("/memfd:" + memfd_rand, EScanElfType::Emulated);
+            info.soinfo = _kMgr->nbScanner.findSoInfo("/memfd:" + memfdName);
+            info.elf = _kMgr->elfScanner.findElf("/memfd:" + memfdName, EScanElfType::Emulated);
             if (!info.elf.isValid())
             {
                 info.elf = _kMgr->elfScanner.createWithSoInfo(info.soinfo);

--- a/AndKittyInjector/src/Injector/KittyInjector.cpp
+++ b/AndKittyInjector/src/Injector/KittyInjector.cpp
@@ -302,7 +302,7 @@ bool KittyInjector::waitBreakpoint(bool needsNB)
     return true;
 }
 
-inject_elf_info_t KittyInjector::inject(const std::string &elfPath)
+inject_elf_info_t KittyInjector::inject(const std::string &elfPath, const std::string &memfdName)
 {
     if (!_kMgr || !_kMgr->isMemValid())
     {
@@ -426,7 +426,7 @@ inject_elf_info_t KittyInjector::inject(const std::string &elfPath)
     if (!emulate)
     {
         KITTY_LOGI("Injector: using nativeInject...");
-        injected = nativeInject(libFile, &bCalldlerror);
+        injected = nativeInject(libFile, &bCalldlerror, memfdName);
     }
     else
     {
@@ -533,7 +533,7 @@ inject_elf_info_t KittyInjector::inject(const std::string &elfPath)
     return injected;
 }
 
-inject_elf_info_t KittyInjector::nativeInject(KittyIOFile &elfFile, bool *bCalldlerror)
+inject_elf_info_t KittyInjector::nativeInject(KittyIOFile &elfFile, bool *bCalldlerror, const std::string &memfdName)
 {
     inject_elf_info_t info{};
     info.is_native = true;
@@ -563,10 +563,10 @@ inject_elf_info_t KittyInjector::nativeInject(KittyIOFile &elfFile, bool *bCalld
     };
 
     auto do_memfd_dlopen = [&]() -> void {
-        std::string memfd_rand = KittyUtils::String::random(KittyUtils::randInt(5, 12));
-        KITTY_LOGI("nativeInject: memfd Name (\"%s\").", memfd_rand.c_str());
 
-        if (!_kMgr->writeMemStr(_rbuffer, memfd_rand))
+        KITTY_LOGI("nativeInject: memfd Name (\"%s\").", memfdName.c_str());
+
+        if (!_kMgr->writeMemStr(_rbuffer, memfdName))
         {
             KITTY_LOGE("nativeInject: Failed to write memfd name into stack!");
             return;

--- a/AndKittyInjector/src/Injector/KittyInjector.hpp
+++ b/AndKittyInjector/src/Injector/KittyInjector.hpp
@@ -57,7 +57,7 @@ struct inject_elf_config_t
 {
     int sdk, rtdl_flags, delay;
     bool watch, launch, seize, bp, memfd, free, hide;
-    std::string package;
+    std::string package, memfd_name;
     std::function<void(inject_elf_info_t &injected)> beforeEntryPoint, afterEntryPoint;
 
     inject_elf_config_t()

--- a/AndKittyInjector/src/Injector/KittyInjector.hpp
+++ b/AndKittyInjector/src/Injector/KittyInjector.hpp
@@ -103,11 +103,11 @@ public:
 
     bool validateElf(const std::string &elfPath, KT_ElfW(Ehdr) * hdr, bool *needsNB);
     bool waitBreakpoint(bool needsNB);
-    inject_elf_info_t inject(const std::string &elfPath);
+    inject_elf_info_t inject(const std::string &elfPath, const std::string &memfdName);
 
 private:
-    inject_elf_info_t nativeInject(KittyIOFile &elfFile, bool *bCalldlerror = nullptr);
-    inject_elf_info_t emuInject(KittyIOFile &elfFile, bool *bCalldlerror = nullptr);
+    inject_elf_info_t nativeInject(KittyIOFile &elfFile, const std::string &memfdName, bool *bCalldlerror = nullptr);
+    inject_elf_info_t emuInject(KittyIOFile &elfFile, const std::string &memfdName, bool *bCalldlerror = nullptr);
 
     bool unloadLibrary(inject_elf_info_t &injected);
     bool hideLibrary(inject_elf_info_t &injected);

--- a/AndKittyInjector/src/main.cpp
+++ b/AndKittyInjector/src/main.cpp
@@ -83,6 +83,11 @@ int main(int argc, char *args[])
 
     program.add_argument("--memfd").help("Use memfd dlopen.").store_into(inj_cfg.memfd);
 
+    program.add_argument("--memfd-name")
+           .help("Set a specific name for the created memfd.")
+           .store_into(inj_cfg.memfd_name)
+           .metavar("<name>");
+
     program.add_argument("--free").help("Unload library after entry point execution.").store_into(inj_cfg.free);
 
     program.add_argument("--hide")
@@ -100,6 +105,10 @@ int main(int argc, char *args[])
         return 1;
     }
 
+    if (inj_cfg.memfd_name.empty()) {
+        inj_cfg.memfd_name = KittyUtils::String::random(KittyUtils::randInt(5, 12));
+    }
+
     KITTY_LOGI("======== INJECTION ARGS ========");
     KITTY_LOGI("package: %s", inj_cfg.package.c_str());
     KITTY_LOGI("sdk: %d", inj_cfg.sdk);
@@ -108,6 +117,7 @@ int main(int argc, char *args[])
     KITTY_LOGI("bp: %d", inj_cfg.bp);
     KITTY_LOGI("delay: %d", inj_cfg.delay);
     KITTY_LOGI("memfd: %d", inj_cfg.memfd ? 1 : 0);
+    KITTY_LOGI("memfd name: %s", inj_cfg.memfd_name.c_str());
     KITTY_LOGI("free: %d", inj_cfg.free);
     KITTY_LOGI("hide: %d", inj_cfg.hide ? 1 : 0);
     for (size_t i = 0; i < libs.size(); i++)
@@ -290,7 +300,7 @@ bool inject(int pid,
     {
         KITTY_LOGI("===== Injecting %s...", it.c_str());
 
-        auto info = injector.inject(it);
+        auto info = injector.inject(it, cfg.memfd_name);
         if (!info.is_valid())
         {
             KITTY_LOGE("===== Failed to inject %s!", it.c_str());

--- a/README.md
+++ b/README.md
@@ -25,20 +25,21 @@ Inject from /data for Android
 Make sure to chmod +x or 755
 
 ```text
-Usage: AndKittyInjector [--help] [--version] --package <name> --libs <paths>... [--launch] [--watch] [--bp] [--delay <micros>] [--memfd] [--free] [--hide]
+Usage: AndKittyInjector [--help] [--version] --package <name> --libs <paths>... [--launch] [--watch] [--bp] [--delay <micros>] [--memfd] [--memfd-name <name>] [--free] [--hide]
 
 Optional arguments:
-  -h, --help        shows help message and exits 
-  -v, --version     prints version information and exits 
-  --package <name>  Target package name to inject into. [required]
-  --libs            Libraries path to be injected. [nargs: 1 or more] [required]
-  --launch          Launch process and inject. 
-  --watch           Monitor process start then inject. 
-  --bp              Inject after breakpoint hit. 
-  --delay <micros>  Delay injection in microseconds. 
-  --memfd           Use memfd dlopen. 
-  --free            Unload library after entry point execution. 
-  --hide            Remove soinfo and remap library to anonymouse memory. 
+  -h, --help           shows help message and exits
+  -v, --version        prints version information and exits
+  --package <name>     Target package name to inject into. [required]
+  --libs               Libraries path to be injected. [nargs: 1 or more] [required]
+  --launch             Launch process and inject.
+  --watch              Monitor process start then inject.
+  --bp                 Inject after breakpoint hit.
+  --delay <micros>     Delay injection in microseconds.
+  --memfd              Use memfd dlopen.
+  --memfd-name <name>  Set a specific name for the created memfd.
+  --free               Unload library after entry point execution.
+  --hide               Remove soinfo and remap library to anonymouse memory.
 ```
 
 Example:


### PR DESCRIPTION
this should be useful to hide from apps that scan the maps file for unexpected memfd's by choosing something like `jit-zygote-cache` (this is useless with --hide)